### PR TITLE
Pass nprocs using the S/R protocol to the migration command

### DIFF
--- a/example/NPB.yml
+++ b/example/NPB.yml
@@ -2,9 +2,12 @@ job-list:
         - nprocs: 16
           threads-per-proc: 1
           cmd: "/home/pickartz/work/benchmarks/NPB/NPB3.3.1/NPB3.3-MPI/bin/cg.C.16"
+          uses-sr-protocol: true
         - nprocs: 16
           threads-per-proc: 1
           cmd: "/home/pickartz/work/benchmarks/NPB/NPB3.3.1/NPB3.3-MPI/bin/cg.C.16"
+          uses-sr-protocol: true
         - nprocs: 16
           threads-per-proc: 1
           cmd: "/home/pickartz/work/benchmarks/NPB/NPB3.3.1/NPB3.3-MPI/bin/ep.C.16"
+          uses-sr-protocol: true

--- a/include/poncos/controller.hpp
+++ b/include/poncos/controller.hpp
@@ -57,6 +57,8 @@ class controllerT {
 	const machine_usageT &machine_usage;
 	// maps ids to the execution configuration
 	const std::vector<execute_config> &id_to_config;
+	// maps ids to the jobs
+	const std::vector<jobT> &id_to_job;
 
   protected:
 	// executed by a new thread, calls system to start the application
@@ -89,6 +91,7 @@ class controllerT {
 	std::vector<std::string> _machines;
 	machine_usageT _machine_usage;
 	std::vector<execute_config> _id_to_config;
+	std::vector<jobT> _id_to_job;
 };
 
 std::ostream &operator<<(std::ostream &os, const controllerT::execute_config_elemT &config_elem);

--- a/include/poncos/job.hpp
+++ b/include/poncos/job.hpp
@@ -5,7 +5,7 @@
 
 struct jobT : public fast::Serializable {
 	jobT() = default;
-	jobT(size_t nprocs, size_t threads_per_proc, std::string command);
+	jobT(size_t nprocs, size_t threads_per_proc, std::string command, bool uses_sr_protocol);
 
 	YAML::Node emit() const override;
 	void load(const YAML::Node &node) override;
@@ -14,6 +14,7 @@ struct jobT : public fast::Serializable {
 	size_t nprocs;
 	size_t threads_per_proc;
 	std::string command;
+	bool uses_sr_protocol;
 };
 std::ostream &operator<<(std::ostream &os, const jobT &job);
 

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -12,7 +12,7 @@ FASTLIB_LOG_SET_LEVEL_GLOBAL(controller_log, info);
 
 controllerT::controllerT(std::shared_ptr<fast::MQTT_communicator> _comm, const std::string &machine_filename)
 	: machines(_machines), available_slots(_available_slots), machine_usage(_machine_usage),
-	  id_to_config(_id_to_config), cmd_counter(0), work_counter_lock(worker_counter_mutex), comm(std::move(_comm)) {
+	  id_to_config(_id_to_config), id_to_job(_id_to_job), cmd_counter(0), work_counter_lock(worker_counter_mutex), comm(std::move(_comm)) {
 
 	// fill the machine file
 	FASTLIB_LOG(controller_log, info) << "Reading machine file " << machine_filename << " ...";
@@ -147,6 +147,7 @@ size_t controllerT::execute(const jobT &job, const execute_config &config, std::
 
 	id_to_tpool.push_back(thread_pool.size());
 	_id_to_config.push_back(config);
+	_id_to_job.push_back(job);
 	for (const auto &i : config) {
 		assert(machine_usage[i.first][i.second] == std::numeric_limits<size_t>::max());
 		_machine_usage[i.first][i.second] = cmd_counter;

--- a/src/controller_vm.cpp
+++ b/src/controller_vm.cpp
@@ -82,12 +82,16 @@ void vm_controller::update_config(const size_t id, const execute_config &new_con
 		const std::string &src_guest = vm_locations[src_host_idx][src_slot];
 		const std::string &dest_guest = vm_locations[dest_host_idx][dest_slot];
 
+		const size_t src_proc_count = (id_to_job[id].nprocs) / old_config.size();
+		const size_t dest_job_id = machine_usage[dest_host_idx][dest_slot];
+		const size_t dest_proc_count = (id_to_job[dest_job_id].nprocs) / id_to_config[dest_job_id].size();
+
 		// generate migrate task and put into task container
 		std::string topic = "fast/migfra/" + src_host + "/task";
-		auto task = std::make_shared<fast::msg::migfra::Migrate>(src_guest, dest_host, "warm", false, true, 0, false);
+		auto task = std::make_shared<fast::msg::migfra::Migrate>(src_guest, dest_host, "warm", false, true, src_proc_count, false);
 		task->swap_with = fast::msg::migfra::Swap_with();
 		task->swap_with.get().vm_name = dest_guest;
-		task->swap_with.get().pscom_hook_procs = "0";
+		task->swap_with.get().pscom_hook_procs = std::to_string(dest_proc_count);
 
 		fast::msg::migfra::Task_container m;
 		m.tasks.push_back(task);

--- a/src/job.cpp
+++ b/src/job.cpp
@@ -2,14 +2,16 @@
 
 #include <fstream>
 
-jobT::jobT(size_t nprocs, size_t threads_per_proc, std::string command)
-	: nprocs(nprocs), threads_per_proc(threads_per_proc), command(std::move(command)) {}
+jobT::jobT(size_t nprocs, size_t threads_per_proc, std::string command, bool uses_sr_protocol)
+	: nprocs(nprocs), threads_per_proc(threads_per_proc),
+	  command(std::move(command)), uses_sr_protocol(uses_sr_protocol) {}
 
 YAML::Node jobT::emit() const {
 	YAML::Node node;
 	node["nprocs"] = nprocs;
 	node["threads-per-proc"] = threads_per_proc;
 	node["cmd"] = command;
+	node["uses-sr-protocol"] = uses_sr_protocol;
 	return node;
 }
 
@@ -17,6 +19,7 @@ void jobT::load(const YAML::Node &node) {
 	fast::load(nprocs, node["nprocs"]);
 	fast::load(threads_per_proc, node["threads-per-proc"]);
 	fast::load(command, node["cmd"]);
+	fast::load(command, node["uses-sr-protocol"]);
 }
 
 job_queueT::job_queueT(std::vector<jobT> jobs) : jobs(std::move(jobs)) {}
@@ -42,6 +45,7 @@ std::ostream &operator<<(std::ostream &os, const jobT &job) {
 	os << "nprocs: " << job.nprocs << "; ";
 	os << "threads-per-proc: " << job.threads_per_proc << "; ";
 	os << "cmd: " << job.command;
+	os << "uses-sr-protocol: " << job.uses_sr_protocol;
 
 	return os;
 }


### PR DESCRIPTION
For a safe migration we need to know the number of processes running within the VMs using the S/R protocol. The auto-mode provided by the migration-framework does not work for all edge cases.