### PR TITLE
fix assertion in cgroup controller

### DIFF
--- a/src/controller_cgroup.cpp
+++ b/src/controller_cgroup.cpp
@@ -111,7 +111,7 @@ std::string cgroup_controller::generate_command(const jobT &job, size_t counter,
 		host_lists[config[i].second].emplace_back(machines[config[i].first]);
 		++hosts_per_slot[config[i].second];
 	}
-	assert(job.req_cpus() ==
+	assert(job.req_cpus() <=
 		   std::accumulate(std::begin(hosts_per_slot), std::end(hosts_per_slot), size_t(0)) * SLOT_SIZE);
 
 	for (size_t slot = 0; slot < SLOTS; ++slot) {


### PR DESCRIPTION
A job may request less cpus than allocated by the scheduler, e.g., the
consec scheduler will always allocate whole nodes regardless of the
job's demand.