### PR TITLE
fix cgroup wrapper for systemd

### DIFF
--- a/script/cgroup_wrapper_systemd.sh
+++ b/script/cgroup_wrapper_systemd.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
 CGROUP="/sys/fs/cgroup/cpuset/$1"
+FREEZER="/sys/fs/cgroup/freezer/$1"
 
 echo "$HOSTNAME: creating cgroup $CGROUP"
 mkdir -p $CGROUP
+mkdir -p $FREEZER
 
 echo "$HOSTNAME: writing $2 to $CGROUP/cpuset.cpus"
 echo $2 > $CGROUP/cpuset.cpus
@@ -14,12 +16,12 @@ echo $3 > $CGROUP/cpuset.mems
 echo "$HOSTNAME: writing $$ to $CGROUP/tasks"
 echo $$ > $CGROUP/tasks
 
+echo "$HOSTNAME: writing $$ to $FREEZER/tasks"
+echo $$ > $FREEZER/tasks
+
 echo "$HOSTNAME: starting ${@:4}"
 ${@:4}
 
-echo "$HOSTNAME: writing $$ to /sys/fs/cgroup/tasks"
-echo $$ > /sys/fs/cgroup/cpuset/tasks
-
-echo "$HOSTNAME: deleting cgroup $CGROUP"
-# ignore error
+# ignore error TODO: we need a post hook deleting the cgroups
 rmdir $CGROUP || true
+rmdir $FREEZER || true


### PR DESCRIPTION
We need to create a freezer cgroup and add the task here as well.
However, the deletion of the cgroups does not work yet.