### PR TITLE
Move config generation into controller

### DIFF
--- a/include/poncos/controller.hpp
+++ b/include/poncos/controller.hpp
@@ -19,7 +19,7 @@
 
 class controllerT {
   public:
-	enum ressource_selector { exclusive, one_slot_per_node };
+	enum resource_selector { exclusive, one_slot_per_node };
 
   public:
 	// entries in the vector are read as: (machine index in machinefiles, #slot)
@@ -55,7 +55,7 @@ class controllerT {
 
 	size_t execute(const jobT &job, const execute_config &config, std::function<void(size_t)> callback);
 
-	void wait_for_ressource(const size_t, const size_t);
+	void wait_for_resource(const size_t, const size_t);
 	void wait_for_change();
 	void wait_for_completion_of(const size_t);
 	void done();
@@ -63,8 +63,8 @@ class controllerT {
 	// unlock the controller, should typically not called by hand
 	void unlock();
 
-	// generates config for requested ressources
-	execute_config generate_config(const size_t requested_cpus, const ressource_selector selector) const;
+	// generates config for requested resources
+	execute_config generate_config(const size_t requested_cpus, const resource_selector selector) const;
 	execute_config generate_opposing_config(const size_t id) const;
 
 	// getters

--- a/include/poncos/controller.hpp
+++ b/include/poncos/controller.hpp
@@ -19,6 +19,9 @@
 
 class controllerT {
   public:
+	enum ressource_selector { exclusive, one_slot_per_node };
+
+  public:
 	// entries in the vector are read as: (machine index in machinefiles, #slot)
 	using execute_config_elemT = std::pair<size_t, size_t>;
 	using execute_config = std::vector<execute_config_elemT>;
@@ -60,6 +63,8 @@ class controllerT {
 	// unlock the controller, should typically not called by hand
 	void unlock();
 
+	// generates config for requested ressources
+	execute_config generate_config(const size_t requested_cpus, const ressource_selector selector) const;
 	execute_config generate_opposing_config(const size_t id) const;
 
 	// getters

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -96,7 +96,7 @@ void controllerT::thaw_opposing(const size_t id) {
 	suspend_resume_config<fast::msg::migfra::Resume>(opposing_config);
 }
 
-void controllerT::wait_for_ressource(const size_t requested, const size_t slots_per_host) {
+void controllerT::wait_for_resource(const size_t requested, const size_t slots_per_host) {
 	if (!work_counter_lock.owns_lock()) work_counter_lock.lock();
 
 	worker_counter_cv.wait(work_counter_lock, [&] {
@@ -249,7 +249,7 @@ void controllerT::execute_command_internal(std::string command, size_t counter,
 	worker_counter_cv.notify_all();
 }
 
-controllerT::execute_config controllerT::generate_config(const size_t requested_cpus, const ressource_selector selector) const {
+controllerT::execute_config controllerT::generate_config(const size_t requested_cpus, const resource_selector selector) const {
 	execute_config config;
 	for (size_t m = 0; m < machine_usage.size(); ++m) {
 		const auto &mu = machine_usage[m];

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -249,6 +249,40 @@ void controllerT::execute_command_internal(std::string command, size_t counter,
 	worker_counter_cv.notify_all();
 }
 
+controllerT::execute_config controllerT::generate_config(const size_t requested_cpus, const ressource_selector selector) const {
+	execute_config config;
+	for (size_t m = 0; m < machine_usage.size(); ++m) {
+		const auto &mu = machine_usage[m];
+
+		switch (selector) {
+		case exclusive: {
+			// take all slots if empty
+			if (mu[0] == std::numeric_limits<size_t>::max()) {
+				for (size_t s = 0; s < SLOTS; ++s) {
+					config.emplace_back(m, s);
+				}
+			}
+			break;
+		}
+		case one_slot_per_node: {
+			// pick one slot per machine
+			for (size_t s = 0; s < SLOTS; ++s) {
+				if (mu[s] == std::numeric_limits<size_t>::max()) {
+					config.emplace_back(m, s);
+					break;
+				}
+			}
+			break;
+		}
+		}
+
+		// we found enough slots
+		if (config.size() * SLOT_SIZE >= requested_cpus) break;
+	}
+
+	return config;
+}
+
 std::string controllerT::cmd_name_from_id(size_t id) const { return std::string("poncos_") + std::to_string(id); }
 
 template <typename T> void controllerT::suspend_resume_config(const execute_config &config) {

--- a/src/scheduler_multi_app.cpp
+++ b/src/scheduler_multi_app.cpp
@@ -211,24 +211,7 @@ void multi_app_sched::schedule(const job_queueT &job_queue, fast::MQTT_communica
 		controller.wait_for_ressource(job.req_cpus(), 1);
 
 		// select ressources
-		controllerT::execute_config config;
-		for (size_t m = 0; m < controller.machine_usage.size(); ++m) {
-			const auto &mu = controller.machine_usage[m];
-
-			// TODO check distgen values here?
-			// -> don't use the ones that are already saturated?
-			// -> prioritize something else?
-
-			// pick one slot per machine
-			for (size_t s = 0; s < SLOTS; ++s) {
-				if (mu[s] == std::numeric_limits<size_t>::max()) {
-					config.emplace_back(m, s);
-					break;
-				}
-			}
-			if (config.size() * SLOT_SIZE == job.req_cpus()) break;
-		}
-
+		controllerT::execute_config config = controller.generate_config(job.req_cpus(), controllerT::one_slot_per_node);
 		assert(config.size() * SLOT_SIZE == job.req_cpus());
 
 		// start job

--- a/src/scheduler_multi_app.cpp
+++ b/src/scheduler_multi_app.cpp
@@ -208,9 +208,9 @@ void multi_app_sched::schedule(const job_queueT &job_queue, fast::MQTT_communica
 	// for all commands
 	for (const auto &job : job_queue.jobs) {
 		assert(job.req_cpus() <= controller.machines.size() * SLOT_SIZE);
-		controller.wait_for_ressource(job.req_cpus(), 1);
+		controller.wait_for_resource(job.req_cpus(), 1);
 
-		// select ressources
+		// select resources
 		controllerT::execute_config config = controller.generate_config(job.req_cpus(), controllerT::one_slot_per_node);
 		assert(config.size() * SLOT_SIZE == job.req_cpus());
 

--- a/src/scheduler_multi_app_consec.cpp
+++ b/src/scheduler_multi_app_consec.cpp
@@ -23,7 +23,7 @@ void multi_app_sched_consec::schedule(const job_queueT &job_queue, fast::MQTT_co
 	// for all commands
 	for (const auto &job : job_queue.jobs) {
 		assert(job.req_cpus() <= controller.machines.size() * SLOT_SIZE * SLOTS);
-		controller.wait_for_ressource(job.req_cpus(), SLOTS);
+		controller.wait_for_resource(job.req_cpus(), SLOTS);
 
 		controllerT::execute_config config = controller.generate_config(job.req_cpus(), controllerT::exclusive);
 		assert(config.size() * SLOT_SIZE >= job.req_cpus());

--- a/src/scheduler_multi_app_consec.cpp
+++ b/src/scheduler_multi_app_consec.cpp
@@ -25,22 +25,7 @@ void multi_app_sched_consec::schedule(const job_queueT &job_queue, fast::MQTT_co
 		assert(job.req_cpus() <= controller.machines.size() * SLOT_SIZE * SLOTS);
 		controller.wait_for_ressource(job.req_cpus(), SLOTS);
 
-		// select ressources
-		controllerT::execute_config config;
-		for (size_t m = 0; m < controller.machine_usage.size(); ++m) {
-			const auto &mu = controller.machine_usage[m];
-
-			// the same job should be running on all slots of a node
-			assert(mu[0] == mu[1]);
-
-			// take all slots if empty
-			if (mu[0] == std::numeric_limits<size_t>::max()) {
-				for (size_t s = 0; s < SLOTS; ++s) {
-					config.emplace_back(m, s);
-				}
-			}
-			if (config.size() * SLOT_SIZE >= job.req_cpus()) break;
-		}
+		controllerT::execute_config config = controller.generate_config(job.req_cpus(), controllerT::exclusive);
 		assert(config.size() * SLOT_SIZE >= job.req_cpus());
 
 		// start job

--- a/src/scheduler_two_app.cpp
+++ b/src/scheduler_two_app.cpp
@@ -26,7 +26,7 @@ void two_app_sched::schedule(const job_queueT &job_queue, fast::MQTT_communicato
 	for (const auto &job : job_queue.jobs) {
 		assert(job.req_cpus() == controller.machines.size() * SLOT_SIZE);
 
-		controller.wait_for_ressource(job.req_cpus(), 1);
+		controller.wait_for_resource(job.req_cpus(), 1);
 
 		// search for a free slot and assign it to a new job
 		size_t new_slot = 0;
@@ -81,7 +81,7 @@ void two_app_sched::schedule(const job_queueT &job_queue, fast::MQTT_communicato
 				FASTLIB_LOG(scheduler_two_app_log, debug) << "0: freezing new";
 				controller.freeze(job_id);
 
-				controller.wait_for_ressource(job.req_cpus(), 1);
+				controller.wait_for_resource(job.req_cpus(), 1);
 
 				FASTLIB_LOG(scheduler_two_app_log, debug) << "0: thaw new";
 				controller.thaw(job_id);


### PR DESCRIPTION
This PR moves the generation of a job's config into the controller. The selection strategy can be passed as parameter. Currently, we only have 2 strategies, therefore the `switch`. Should we move this into an own class?